### PR TITLE
Install quarto.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions
 
-# https://github.com/rocker-org/rocker-versioned2/wiki/verse_0f4b22fe3b8c
+# https://github.com/rocker-org/rocker-versioned2/wiki/verse_c41250521d1f
 FROM rocker/verse:4.3.1
 
 ENV TZ=Etc/UTC
@@ -25,6 +25,13 @@ RUN apt-get update && \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# While quarto is included with rocker/verse, we sometimes need different
+# versions than the default. For example a newer version might fix bugs.
+ENV _QUARTO_VERSION=1.3.433
+RUN curl -L -o /tmp/quarto.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${_QUARTO_VERSION}/quarto-${_QUARTO_VERSION}-linux-amd64.deb
+RUN apt-get install /tmp/quarto.deb && \
+    rm -f /tmp/quarto.deb
 
 COPY set-libs.r /tmp/set-libs.r
 


### PR DESCRIPTION
rocker/verse already includes it, but this version fixes a problem in the one shipped in the image. It may be necessary to upgrade or downgrade this version from time to time.